### PR TITLE
replacing view with pure because isWrappedJetton doesn't use state va…

### DIFF
--- a/contracts/SignatureChecker.sol
+++ b/contracts/SignatureChecker.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.9;
-pragma experimental ABIEncoderV2;
 
 import "./TonUtils.sol";
 

--- a/contracts/TestWrappedJetton.sol
+++ b/contracts/TestWrappedJetton.sol
@@ -8,7 +8,7 @@ contract TestWrappedJetton is ERC20 {
         _mint(msg.sender, 2000000e18);
     }
 
-    function isWrappedJetton() external view returns (bool) {
+    function isWrappedJetton() external pure returns (bool) {
         return true;
     }
 }


### PR DESCRIPTION
replacing view with pure because isWrappedJetton doesn't use state variables

starting from Solidity v0.8 and higher, the ABIEncoderV2 is not experimental anymore - it is actually enabled by default by the compiler

my address: EQCxB491aXem_D5dvCvXv48Xii2XpPZwuyJ9DMNiIo2Z7UkG